### PR TITLE
fix(code_block): pass tool kwarg to on_before_reply_app

### DIFF
--- a/src/dolphin/core/code_block/basic_code_block.py
+++ b/src/dolphin/core/code_block/basic_code_block.py
@@ -1305,12 +1305,12 @@ class BasicCodeBlock:
             self.context.warn(f"toolkit is None, tool_name[{tool_name}]")
             return
 
-        skill = self.context.get_tool(tool_name)
-        if not skill:
+        tool = self.context.get_tool(tool_name)
+        if not tool:
             from dolphin.lib.toolkits.system_toolkit import SystemFunctions
-            skill = SystemFunctions.getTool(tool_name)
+            tool = SystemFunctions.getTool(tool_name)
 
-        if skill is None:
+        if tool is None:
             async for result in self.yield_message(
                 f"没有{tool_name}工具可以调用！", ""
             ):
@@ -1392,7 +1392,7 @@ class BasicCodeBlock:
             # NOTE: Do NOT call yield_message() in resume branch!
             # The resumed tool execution will create the stage naturally through recorder.update()
 
-        agent_as_tool = self.context.get_agent_tool(skill)
+        agent_as_tool = self.context.get_agent_tool(tool)
         if agent_as_tool is not None:
             cur_agent = self.context.get_cur_agent()
             if (
@@ -1427,7 +1427,7 @@ class BasicCodeBlock:
             # Default: all tool calls support interrupt if tool has interrupt_config
             # Skip interrupt check if this is a resumed tool call (intervention=False)
             if props.get('intervention', True):
-                interrupt_config = getattr(skill, 'interrupt_config', None)
+                interrupt_config = getattr(tool, 'interrupt_config', None)
                 
                 if interrupt_config and interrupt_config.get('requires_confirmation'):
                     # Format confirmation message (support parameter interpolation)
@@ -1454,7 +1454,7 @@ class BasicCodeBlock:
                     )
             
             console_tool_call(
-                tool_name, skill_params_json, verbose=self.context.verbose, skill=skill, is_cli=self.context.is_cli_mode()
+                tool_name, skill_params_json, verbose=self.context.verbose, skill=tool, is_cli=self.context.is_cli_mode()
             )
             if agent_as_tool is not None:
                 console_agent_tool_enter(tool_name, verbose=self.context.verbose, is_cli=self.context.is_cli_mode())
@@ -1463,7 +1463,7 @@ class BasicCodeBlock:
             import time
             tool_start_time = time.time()
             trace_listener = getattr(self.context, 'trace_listener', None)
-            tool_type = getattr(skill, 'skill_type', 'function') if hasattr(skill, 'skill_type') else 'function'
+            tool_type = getattr(tool, 'skill_type', 'function') if hasattr(tool, 'skill_type') else 'function'
             trace_context_kwargs = self._build_trace_context_kwargs()
             
             if trace_listener:
@@ -1482,7 +1482,7 @@ class BasicCodeBlock:
             result = None
             try:
                 async for result in Toolkit.arun(
-                    tool=skill,
+                    tool=tool,
                     tool_params=skill_params_json if skill_params_json is not None else {},
                     props=props,
                 ):
@@ -1530,7 +1530,7 @@ class BasicCodeBlock:
                     # Process the response data to return to frontend
                     try:
                         result = self.toolkit_hook.on_before_reply_app(
-                            reference_id=ref.reference_id, skill=skill
+                            reference_id=ref.reference_id, tool=tool
                         )
                     except Exception as e:
                         raise e
@@ -1635,7 +1635,7 @@ class BasicCodeBlock:
                 response=answer,
                 max_length=1024,
                 verbose=self.context.verbose,
-                skill=skill,
+                skill=tool,
                 params=skill_params_json,
                 is_cli=self.context.is_cli_mode(),
             )


### PR DESCRIPTION
Closes #58

## Summary
- `basic_code_block.tool_run` 原本向 `on_before_reply_app` 传 `skill=skill`，改名后该 kwarg 已不存在，被 `**kwargs` 静默吞掉，`tool` 保持默认 `None`，导致 `tool.get_first_valid_app_strategy()` 抛 `AttributeError`（被内部 except 捕获，持续刷 error log，app 侧收到 `{"error": "数据处理failed"}`）
- 修正 kwarg 为 `tool=`，并把 `tool_run` 函数体（1296-1658）里遗留的 11 处局部变量 `skill` 统一改名为 `tool`；外部 `console_tool_call`/`console_tool_response` 形参仍叫 `skill`，故保留 keyword 只换 value

## Test plan
- [x] `make test-unit`：1448 passed / 15 skipped / 0 failed（observability 用例需本地先 `uv pip install opentelemetry-api opentelemetry-sdk`）
- [ ] 人工验证：tool 调用在 app 模式下返回正常结构，error log 不再刷

🤖 Generated with [Claude Code](https://claude.com/claude-code)