### PR TITLE
fix(#67): return deterministic error for unknown tool calls

### DIFF
--- a/src/dolphin/core/code_block/basic_code_block.py
+++ b/src/dolphin/core/code_block/basic_code_block.py
@@ -289,6 +289,11 @@ class BasicCodeBlock:
     preserve tool call traces in the trajectory.
     """
 
+    UNKNOWN_SKILL_LOADER_HINTS = (
+        ("_load_resource_skill", "resource skill"),
+        ("builtin_skill_load", "built-in skill package"),
+    )
+
     def __init__(self, context: Context):
         self.context = context
         self._history_persistence_engine = _HistoryPersistenceEngine()
@@ -1301,6 +1306,133 @@ class BasicCodeBlock:
     def get_skillkit(self):
         """获取当前代码块可用的技能集（仅依赖 Context.get_skillkit 主流程逻辑）"""
         return self.context.get_skillkit(self.skills)
+
+    def _resolve_skill_or_system_skill(self, skill_name: str):
+        """Resolve a skill from the current context or built-in system skills."""
+        skill = None
+        try:
+            skill = self.context.get_skill(skill_name)
+        except Exception as exc:
+            logger.debug(
+                f"Failed to resolve skill '{skill_name}' from context: {exc}",
+                exc_info=True,
+            )
+            skill = None
+
+        if not skill:
+            try:
+                from dolphin.lib.skillkits.system_skillkit import SystemFunctions
+
+                skill = SystemFunctions.getSkill(skill_name)
+            except Exception as exc:
+                logger.debug(
+                    f"Failed to resolve skill '{skill_name}' from system skills: {exc}",
+                    exc_info=True,
+                )
+                skill = None
+        return skill
+
+    def _get_available_skill_names_for_error(self) -> list[str]:
+        """Return available skill names for an actionable model-facing error."""
+        names: list[str] = []
+
+        def extend_from_skillkit(skillkit):
+            if skillkit is None or not hasattr(skillkit, "getSkillNames"):
+                return
+            try:
+                names.extend(str(name) for name in skillkit.getSkillNames())
+            except Exception as exc:
+                logger.debug(
+                    f"Failed to collect skill names from skillkit: {exc}",
+                    exc_info=True,
+                )
+                return
+
+        # Include the effective skillkit exposed to the current block.
+        try:
+            extend_from_skillkit(self.get_skillkit())
+        except Exception as exc:
+            logger.debug(
+                f"Failed to collect effective skill names: {exc}",
+                exc_info=True,
+            )
+
+        # Include the raw context skillkit as a fallback when block-level filters
+        # hide useful names from the recovery hint.
+        try:
+            extend_from_skillkit(getattr(self.context, "skillkit", None))
+        except Exception as exc:
+            logger.debug(
+                f"Failed to collect context skill names: {exc}",
+                exc_info=True,
+            )
+
+        try:
+            from dolphin.lib.skillkits.system_skillkit import SystemFunctions
+
+            for skill in SystemFunctions.getSkills():
+                names.append(str(skill.get_function_name()))
+        except Exception as exc:
+            logger.debug(
+                f"Failed to collect system skill names: {exc}",
+                exc_info=True,
+            )
+
+        return sorted(set(name for name in names if name))
+
+    def _build_unknown_skill_error_message(self, skill_name: str) -> str:
+        """Build a deterministic tool response for unknown skill calls."""
+        available_names = self._get_available_skill_names_for_error()
+        if available_names:
+            available = ", ".join(available_names)
+            message = (
+                f"Tool '{skill_name}' not found. Available tools: {available}."
+            )
+        else:
+            message = (
+                f"Tool '{skill_name}' not found. No tools are currently available."
+            )
+
+        for loader_name, label in self.UNKNOWN_SKILL_LOADER_HINTS:
+            if loader_name in available_names:
+                message += (
+                    f" If you meant the {label} '{skill_name}', "
+                    f"call {loader_name}(\"{skill_name}\") first."
+                )
+                break
+
+        return message
+
+    def _get_unknown_skill_error_payload(
+        self, skill_name: str
+    ) -> Optional[tuple[str, dict]]:
+        """Return an error payload when a skill name is not executable."""
+        if self._resolve_skill_or_system_skill(skill_name) is not None:
+            return None
+        return self._build_unknown_skill_error_message(skill_name), {
+            "error": "unknown_tool"
+        }
+
+    def _append_tool_response(
+        self,
+        tool_call_id: str,
+        content: str,
+        metadata: Optional[dict] = None,
+    ):
+        """Append a tool response message to the block-specific context store."""
+        raise NotImplementedError
+
+    def _append_unknown_skill_tool_response(
+        self, skill_name: str, tool_call_id: str
+    ) -> Optional[str]:
+        """Append a deterministic tool response for unknown skill calls."""
+        payload = self._get_unknown_skill_error_payload(skill_name)
+        if payload is None:
+            return None
+
+        content, metadata = payload
+        self._append_tool_response(tool_call_id, content, metadata)
+        return content
 
     async def skill_run(
         self,

--- a/src/dolphin/core/code_block/explore_block.py
+++ b/src/dolphin/core/code_block/explore_block.py
@@ -750,6 +750,18 @@ Please reconsider your approach and improve your answer based on the feedback ab
         try:
             props = {"intervention": False, "saved_stage_id": saved_stage_id}
             have_answer = False
+            tool_call_id = self._extract_tool_call_id()
+            if not tool_call_id:
+                tool_call_id = f"call_{function_name}_{self.times}"
+            unknown_skill_error = self._append_unknown_skill_tool_response(
+                function_name, tool_call_id
+            )
+            if unknown_skill_error is not None:
+                return_answer["answer"] = unknown_skill_error
+                return_answer["think"] = ""
+                return_answer["status"] = "failed"
+                yield [return_answer]
+                return
 
             async for resp in self.skill_run(
                 skill_name=function_name,
@@ -1040,6 +1052,13 @@ Please reconsider your approach and improve your answer based on the feedback ab
                 "stage_id": None,  # Will be updated by skill_run() after stage creation
             }
 
+            unknown_skill_error = self._append_unknown_skill_tool_response(
+                tool_call.name, tool_call.id
+            )
+            if unknown_skill_error is not None:
+                tool_response_added = True
+                return
+
             self.context.set_variable(intervention_tmp_key, intervention_vars)
 
             async for resp in self.skill_run(
@@ -1244,6 +1263,20 @@ Please reconsider your approach and improve your answer based on the feedback ab
         error_trace = traceback.format_exc()
         self.context.error(
             f"error in call {tool_name} tool, error type: {type(e)}, error info: {str(e)}, error trace: {error_trace}"
+        )
+
+    def _append_tool_response(
+        self,
+        tool_call_id: str,
+        content: str,
+        metadata: Optional[dict] = None,
+    ):
+        """Append a tool response message through the active explore strategy."""
+        self.strategy.append_tool_response_message(
+            self.context,
+            tool_call_id,
+            content,
+            metadata=metadata,
         )
 
     async def _should_continue_explore(self) -> bool:

--- a/src/dolphin/core/code_block/explore_block_v2.py
+++ b/src/dolphin/core/code_block/explore_block_v2.py
@@ -489,6 +489,18 @@ class ExploreBlockV2(BasicCodeBlock):
         try:
             props = {"intervention": False, "saved_stage_id": saved_stage_id}
             have_answer = False
+            tool_call_id = self._extract_tool_call_id()
+            if not tool_call_id:
+                tool_call_id = f"call_{function_name}_{self.times}"
+            unknown_skill_error = self._append_unknown_skill_tool_response(
+                function_name, tool_call_id
+            )
+            if unknown_skill_error is not None:
+                return_answer["answer"] = unknown_skill_error
+                return_answer["think"] = ""
+                return_answer["status"] = "failed"
+                yield [return_answer]
+                return
 
             async for resp in self.skill_run(
                 skill_name=function_name,
@@ -684,6 +696,12 @@ class ExploreBlockV2(BasicCodeBlock):
                 "stage_id": None,  # Will be updated by skill_run() after stage creation
             }
 
+            unknown_skill_error = self._append_unknown_skill_tool_response(
+                stream_item.tool_name, tool_call_id
+            )
+            if unknown_skill_error is not None:
+                return
+
             self.context.set_variable(intervention_tmp_key, intervention_vars)
 
             async for resp in self.skill_run(
@@ -758,6 +776,15 @@ class ExploreBlockV2(BasicCodeBlock):
         self.context.error(
             f"error in call {tool_name} tool, error type: {type(e)}, error info: {str(e)}, error trace: {error_trace}"
         )
+
+    def _append_tool_response(
+        self,
+        tool_call_id: str,
+        content: str,
+        metadata: Optional[dict] = None,
+    ):
+        """Append a tool response message to the scratchpad."""
+        self._append_tool_message(tool_call_id, content, metadata)
 
     def _should_continue_explore(self) -> bool:
         """Check whether to continue the next exploration.

--- a/tests/unittest/blocks/test_explore_block.py
+++ b/tests/unittest/blocks/test_explore_block.py
@@ -29,6 +29,9 @@ from dolphin.core.context.context import Context
 from dolphin.core.context_engineer.config.settings import BuildInBucket
 from dolphin.core.context_engineer.core.context_manager import ContextManager
 from dolphin.core.config.global_config import GlobalConfig
+from dolphin.core.runtime.runtime_instance import ProgressInstance
+from dolphin.core.trajectory.recorder import Recorder
+from dolphin.core.common.enums import TypeStage
 from dolphin.core.skill.skill_function import SkillFunction
 from dolphin.core.skill.skillset import Skillset
 
@@ -62,6 +65,26 @@ def mock_execute_sql(sql: str, datasource: str):
         datasource (str): Database datasource name
     """
     return f"Executing: {sql} on {datasource}"
+
+
+def _tool_a():
+    """Mock tool A for tool-call execution tests."""
+    return "tool-a"
+
+
+def _tool_b():
+    """Mock tool B for tool-call execution tests."""
+    return "tool-b"
+
+
+def _good_tool():
+    """Mock valid tool for mixed multi-tool execution tests."""
+    return "good"
+
+
+def _search(q: str):
+    """Mock search tool for duplicate-call tests."""
+    return f"Search results for: {q}"
 
 
 class MockSkillkit:
@@ -163,6 +186,10 @@ class TestExploreBlockShouldContinueExplore(unittest.TestCase):
         global_config = GlobalConfig()
         context = Context(config=global_config, context_manager=context_manager)
         context._calc_all_skills()
+        skillset = Skillset()
+        for func in (mock_search, _tool_a, _tool_b, _good_tool, _search):
+            skillset.addSkill(SkillFunction(func))
+        context.set_skills(skillset)
 
         block = ExploreBlock(context=context)
         block.times = 0
@@ -762,6 +789,10 @@ class TestExecuteToolCallInterruptGuarantees(unittest.TestCase):
         global_config = GlobalConfig()
         context = Context(config=global_config, context_manager=context_manager)
         context._calc_all_skills()
+        skillset = Skillset()
+        for func in (mock_search, _tool_a, _tool_b, _good_tool, _search):
+            skillset.addSkill(SkillFunction(func))
+        context.set_skills(skillset)
 
         block = ExploreBlock(context=context)
         block.recorder = MagicMock()
@@ -784,7 +815,7 @@ class TestExecuteToolCallInterruptGuarantees(unittest.TestCase):
 
         stream_item = StreamItem()
         stream_item.answer = "calling tool"
-        tool_call = ToolCall(id="call_err", name="_tool", arguments={})
+        tool_call = ToolCall(id="call_err", name="mock_search", arguments={})
 
         async def run():
             async for _ in block._execute_tool_call(stream_item, tool_call):
@@ -813,7 +844,7 @@ class TestExecuteToolCallInterruptGuarantees(unittest.TestCase):
 
         stream_item = StreamItem()
         stream_item.answer = "calling tool"
-        tool_call = ToolCall(id="call_ti", name="_tool", arguments={})
+        tool_call = ToolCall(id="call_ti", name="mock_search", arguments={})
 
         async def run():
             async for _ in block._execute_tool_call(stream_item, tool_call):
@@ -826,6 +857,52 @@ class TestExecuteToolCallInterruptGuarantees(unittest.TestCase):
         block.strategy.append_tool_response_message.assert_called()
         call_args = block.strategy.append_tool_response_message.call_args
         self.assertIn("interrupted", call_args[0][2].lower())
+
+    def test_unknown_skill_uses_previous_llm_answer_as_tool_response(self):
+        """Unknown skills should not reuse the previous LLM stage as tool output."""
+        context_manager = ContextManager()
+        global_config = GlobalConfig()
+        context = Context(config=global_config, context_manager=context_manager)
+        context._calc_all_skills()
+        context.runtime_graph = None
+        skillset = Skillset()
+        skillset.addSkill(SkillFunction(mock_search))
+        context.set_skills(skillset)
+
+        block = ExploreBlock(context=context)
+        progress = ProgressInstance(context)
+        leaked_llm_text = (
+            'I need to call the web tool now. '
+            '<seed:tool_call><function name="web">'
+        )
+        progress.add_stage(
+            stage=TypeStage.LLM,
+            answer=leaked_llm_text,
+            raw_output="",
+        )
+        block.recorder = Recorder(context=context, progress=progress)
+        block.strategy.get_deduplicator = MagicMock(return_value=MagicMock())
+        block.strategy.append_tool_response_message = MagicMock()
+
+        stream_item = StreamItem()
+        stream_item.answer = leaked_llm_text
+        tool_call = ToolCall(
+            id="call_unknown_web",
+            name="web",
+            arguments={"action": "fetch_page"},
+        )
+
+        async def run():
+            async for _ in block._execute_tool_call(stream_item, tool_call):
+                pass
+
+        asyncio.run(run())
+
+        block.strategy.append_tool_response_message.assert_called()
+        call_args = block.strategy.append_tool_response_message.call_args
+        assert call_args[0][1] == "call_unknown_web"
+        assert leaked_llm_text not in call_args[0][2]
+        assert "Tool 'web' not found" in call_args[0][2]
 
     def test_user_interrupt_in_check_still_adds_tool_response(self):
         """check_user_interrupt() raising UserInterrupt must still add tool response.
@@ -865,6 +942,10 @@ class TestExecuteToolCallsSequential(unittest.TestCase):
         global_config = GlobalConfig()
         context = Context(config=global_config, context_manager=context_manager)
         context._calc_all_skills()
+        skillset = Skillset()
+        for func in (mock_search, _tool_a, _tool_b, _good_tool, _search):
+            skillset.addSkill(SkillFunction(func))
+        context.set_skills(skillset)
 
         block = ExploreBlock(context=context)
         block.recorder = MagicMock()

--- a/tests/unittest/blocks/test_explore_block_v2.py
+++ b/tests/unittest/blocks/test_explore_block_v2.py
@@ -15,7 +15,16 @@ from dolphin.core.context_engineer.core.context_manager import (
     ContextManager,
 )
 from dolphin.core.config.global_config import GlobalConfig
-from dolphin.core.common.enums import StreamItem, MessageRole
+from dolphin.core.common.enums import StreamItem, MessageRole, TypeStage
+from dolphin.core.runtime.runtime_instance import ProgressInstance
+from dolphin.core.trajectory.recorder import Recorder
+from dolphin.core.skill.skill_function import SkillFunction
+from dolphin.core.skill.skillset import Skillset
+
+
+def mock_search(query: str):
+    """Return a deterministic mock search result."""
+    return f"Search results for: {query}"
 
 
 class TestExploreBlockV2(unittest.TestCase):
@@ -96,6 +105,9 @@ class TestExploreBlockV2(unittest.TestCase):
         context = Context(config=global_config, context_manager=context_manager)
         context._calc_all_skills()
         context.error = MagicMock()
+        skillset = Skillset()
+        skillset.addSkill(SkillFunction(mock_search))
+        context.set_skills(skillset)
         
         # Mock bucket operations
         bucket_messages = []
@@ -112,11 +124,11 @@ class TestExploreBlockV2(unittest.TestCase):
         
         # Mock stream item with tool call
         stream_item = MagicMock(spec=StreamItem)
-        stream_item.tool_name = "browser_tool"
+        stream_item.tool_name = "mock_search"
         stream_item.tool_args = {}
         stream_item.answer = "Calling browser..."
         stream_item.get_tool_call.return_value = {
-            "name": "browser_tool",
+            "name": "mock_search",
             "arguments": {}
         }
         
@@ -145,6 +157,50 @@ class TestExploreBlockV2(unittest.TestCase):
                     found_error = True
                     break
         self.assertTrue(found_error, "Tool response should contain the error message")
+
+    def test_unknown_skill_uses_previous_llm_answer_as_tool_response(self):
+        """Unknown skills should not reuse the previous LLM stage as tool output."""
+        context_manager = ContextManager()
+        global_config = GlobalConfig()
+        context = Context(config=global_config, context_manager=context_manager)
+        context._calc_all_skills()
+        context.runtime_graph = None
+        skillset = Skillset()
+        skillset.addSkill(SkillFunction(mock_search))
+        context.set_skills(skillset)
+
+        block = ExploreBlockV2(context=context)
+        progress = ProgressInstance(context)
+        leaked_llm_text = (
+            'I need to call the web tool now. '
+            '<seed:tool_call><function name="web">'
+        )
+        progress.add_stage(
+            stage=TypeStage.LLM,
+            answer=leaked_llm_text,
+            raw_output="",
+        )
+        block.recorder = Recorder(context=context, progress=progress)
+        block._append_tool_message = MagicMock()
+
+        stream_item = StreamItem()
+        stream_item.tool_name = "web"
+        stream_item.tool_args = {"action": "fetch_page"}
+        stream_item.answer = leaked_llm_text
+
+        async def run_test():
+            async for _ in block._execute_tool_call(
+                stream_item, "call_unknown_web"
+            ):
+                pass
+
+        asyncio.run(run_test())
+
+        block._append_tool_message.assert_called()
+        call_args = block._append_tool_message.call_args
+        assert call_args[0][0] == "call_unknown_web"
+        assert leaked_llm_text not in call_args[0][1]
+        assert "Tool 'web' not found" in call_args[0][1]
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unittest/system/test_trajectory.py
+++ b/tests/unittest/system/test_trajectory.py
@@ -111,7 +111,10 @@ class MockSkillkit:
         return list(self._skills.keys())
 
     def getSkill(self, name: str) -> Any:
-        """在本测试中不直接通过 skillkit 调用工具，返回 None"""
+        """Return a declared mock skill by name."""
+        for skill in self.getSkills():
+            if skill.get_function_name() == name:
+                return skill
         return None
 
     def getSchemas(self, skill_names=None) -> str:


### PR DESCRIPTION
## Summary

Fixes #67.

This PR makes unknown tool calls deterministic and protocol-safe across both explore execution paths. When the model calls a tool that is not registered in the current context, Dolphin now appends a proper `role=tool` response with an actionable `unknown_tool` error instead of falling through to the normal skill execution path.

## Problem

Before this change, an unregistered tool call could fall through to `_process_skill_result_with_hook` / normal skill result handling. In that path, Dolphin could reuse the previous LLM stage answer as the tool response.

That created two concrete risks:

- The assistant's partial text, including tool-call markup, could be written back as if it were real tool output.
- The OpenAI-compatible tool-call protocol could become misleading or brittle because the tool response did not describe the actual failure.

Example failure mode:

```text
assistant emits tool_call: web(...)
Dolphin cannot resolve tool `web`
previous LLM text is reused as tool output
next LLM turn receives assistant text disguised as a tool result
```

## What Changed

- Added shared unknown-tool helpers in `BasicCodeBlock`:
  - Resolve a tool against the current context and system skills.
  - Collect available tool names for an actionable error message.
  - Build a deterministic unknown-tool payload with `error: unknown_tool`.
  - Append a block-specific tool response through a shared hook.
- Updated `ExploreBlock` to short-circuit unknown tool calls before `skill_run()` side effects.
- Updated `ExploreBlockV2` with the same behavior for the v2 tool-call path.
- Added loader hints when resource/built-in skill loader tools are available, so the model can recover by loading the intended skill first.
- Updated trajectory test mock skill lookup so declared mock skills resolve like real skills.

## New Behavior

When the model calls an unavailable tool, Dolphin now sends a valid tool response back into the conversation:

```json
{
  "role": "tool",
  "content": "Tool 'missingTool' not found. Available tools: ...",
  "error": "unknown_tool",
  "tool_call_id": "call_missingTool_1"
}
```

This keeps the assistant `tool_calls` -> `tool` response pairing intact and gives the model a clear chance to recover or choose a valid tool.

## Notes On `_progress`

This fix is intentionally focused on message protocol correctness. The unknown-tool response is currently written into the tool-response message stream, not surfaced as a separate `_progress` item.

That means UI or callers consuming only `_progress` may not see an explicit `unknown_tool` progress event yet. Surfacing unknown-tool failures in `_progress` would be a follow-up observability enhancement, not part of this protocol fix.

## Validation

Automated tests:

```bash
python -m pytest \
  tests/unittest/blocks/test_explore_block_v2.py::TestExploreBlockV2::test_unknown_skill_uses_previous_llm_answer_as_tool_response \
  tests/unittest/blocks/test_explore_block.py::TestExecuteToolCallInterruptGuarantees::test_unknown_skill_uses_previous_llm_answer_as_tool_response \
  -q
```

Result:

```text
2 passed
```

Manual e2e-style validation with a local OpenAI-compatible mock server:

- First LLM response returned a tool call for unregistered `missingTool`.
- Dolphin appended a `role=tool` response containing `Tool 'missingTool' not found...` and `error: unknown_tool`.
- Dolphin then continued to the next LLM turn with the tool-call protocol closed correctly.

Observed second request last message:

```json
{
  "role": "tool",
  "content": "Tool 'missingTool' not found. Available tools: ...",
  "error": "unknown_tool",
  "tool_call_id": "call_missingTool_1"
}
```

## Risk

Low. The change short-circuits only unresolved tools. Registered context tools and system tools still use the existing execution path.
